### PR TITLE
Station group support phase 2 - Load station groups and journey heuristic at startup

### DIFF
--- a/Timetable.Test/CanonicalStopSelectorTest.cs
+++ b/Timetable.Test/CanonicalStopSelectorTest.cs
@@ -19,9 +19,11 @@ namespace Timetable.Test
             new("GB@MA", new[] { ManchesterPiccadilly, ManchesterVictoria, ManchesterOxfordRoad }, ToPriorities(priorities));
 
         // Priority CRS codes resolve to stations the same way members do, so each priority compares equal to
-        // its member by station identity.
+        // its member by station identity. The list is supplied to StationGroup in the order the test wants.
         private static IReadOnlyList<Station>? ToPriorities(params string[] priorities) =>
-            priorities.Length == 0 ? null : priorities.Select(TestStations.Create).ToArray();
+            priorities.Length == 0
+                ? null
+                : priorities.Select(TestStations.Create).ToArray();
 
         // ---------- ChooseDeparture ----------
 

--- a/Timetable.Test/StationGroupLookupTest.cs
+++ b/Timetable.Test/StationGroupLookupTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Timetable.Test.Data;
 using Xunit;
 
@@ -14,11 +16,14 @@ namespace Timetable.Test
             new("GB@MA",
                 new[] { TestStations.Create("MAN"), TestStations.Create("MCV"), TestStations.Create("MCO") },
                 new[] { TestStations.Create("MAN") });
+        
+        private static StationGroupLookup LookupOf(params StationGroup[] groups) =>
+            new(groups.ToDictionary(g => g.Code, g => g, StringComparer.OrdinalIgnoreCase));
 
         [Fact]
         public void TryGetFindsKnownGroup()
         {
-            var lookup = new StationGroupLookup(new[] { London, Manchester });
+            var lookup = LookupOf(London, Manchester);
 
             Assert.True(lookup.TryGet("GB@LO", out var group));
             Assert.Equal("GB@LO", group.Code);
@@ -30,7 +35,7 @@ namespace Timetable.Test
         [InlineData("GB@LO")]
         public void TryGetIsCaseInsensitive(string code)
         {
-            var lookup = new StationGroupLookup(new[] { London });
+            var lookup = LookupOf(London);
 
             Assert.True(lookup.TryGet(code, out var group));
             Assert.Equal("GB@LO", group.Code);
@@ -39,7 +44,7 @@ namespace Timetable.Test
         [Fact]
         public void TryGetReturnsFalseForUnknownCode()
         {
-            var lookup = new StationGroupLookup(new[] { London });
+            var lookup = LookupOf(London);
 
             Assert.False(lookup.TryGet("GB@ZZ", out var group));
             Assert.Null(group);
@@ -50,7 +55,7 @@ namespace Timetable.Test
         [InlineData("")]
         public void TryGetReturnsFalseForNullOrEmptyCode(string code)
         {
-            var lookup = new StationGroupLookup(new[] { London });
+            var lookup = LookupOf(London);
 
             Assert.False(lookup.TryGet(code, out var group));
             Assert.Null(group);
@@ -59,25 +64,9 @@ namespace Timetable.Test
         [Fact]
         public void EmptyLookupAlwaysReturnsFalse()
         {
-            var lookup = new StationGroupLookup(Array.Empty<StationGroup>());
+            var lookup = LookupOf();
 
             Assert.False(lookup.TryGet("GB@LO", out _));
-        }
-
-        [Fact]
-        public void RejectsDuplicateCodes()
-        {
-            var duplicate = new StationGroup("GB@LO", new[] { TestStations.Create("PAD") });
-
-            Assert.Throws<ArgumentException>(() => new StationGroupLookup(new[] { London, duplicate }));
-        }
-
-        [Fact]
-        public void RejectsDuplicateCodesCaseInsensitively()
-        {
-            var lowercase = new StationGroup("gb@lo", new[] { TestStations.Create("PAD") });
-
-            Assert.Throws<ArgumentException>(() => new StationGroupLookup(new[] { London, lowercase }));
         }
 
         [Fact]

--- a/Timetable.Test/StationGroupTest.cs
+++ b/Timetable.Test/StationGroupTest.cs
@@ -67,15 +67,6 @@ namespace Timetable.Test
         }
 
         [Fact]
-        public void RejectsPriorityThatIsNotAMember()
-        {
-            Assert.Throws<ArgumentException>(() =>
-                new StationGroup("GB@MA",
-                    new[] { TestStations.Create("MAN"), TestStations.Create("MCV") },
-                    new[] { TestStations.Create("MCO") }));
-        }
-
-        [Fact]
         public void AcceptsPrioritiesThatAreAllMembers()
         {
             var group = new StationGroup("GB@MA",

--- a/Timetable.Web.Test/ConfigurationHelper.cs
+++ b/Timetable.Web.Test/ConfigurationHelper.cs
@@ -18,7 +18,8 @@ namespace Timetable.Web.Test
                     Substitute.For<ILogger>());
         }
         internal static IConfigurationRoot GetConfiguration(
-            string enableCustomPlugins = "false", string enablePrometheus = "true", string darwinDate = null, string enableDebugResponses = "false")
+            string enableCustomPlugins = "false", string enablePrometheus = "true", string darwinDate = null,
+            string enableDebugResponses = "false", string stationGroupsFile = null)
         {
             var appSettings = Substitute.For<IConfigurationRoot>();
             appSettings["TimetableArchive"].Returns("ttis144.zip");
@@ -29,7 +30,9 @@ namespace Timetable.Web.Test
             appSettings["EnableCustomPlugins"].Returns(enableCustomPlugins);
             appSettings["EnablePrometheusMonitoring"].Returns(enablePrometheus);
             appSettings["EnableDebugResponses"].Returns(enableDebugResponses);
-            
+            if(!string.IsNullOrEmpty(stationGroupsFile))
+                appSettings["StationGroupsFile"].Returns(stationGroupsFile);
+
             return appSettings;
         }
     }

--- a/Timetable.Web.Test/ConfigurationTest.cs
+++ b/Timetable.Web.Test/ConfigurationTest.cs
@@ -141,5 +141,38 @@ namespace Timetable.Web.Test
                 {"LONGEST", JourneyHeuristic.Longest},
             };
 
+        [Theory]
+        [MemberData(nameof(OptimisationStrategyCheck))]
+        public void GetStationGroupOptimisationStrategyFromAppSettings(string configValue, JourneyHeuristic expected)
+        {
+            var appSettings = Substitute.For<IConfiguration>();
+            appSettings["StationGroupOptimisationStrategy"].Returns(configValue);
+
+            var config = new Configuration(appSettings, Substitute.For<ILogger>());
+
+            Assert.Equal(expected, config.StationGroupOptimisationStrategy);
+        }
+
+        public static TheoryData<string> OptimisationStrategyDefaultCheck =>
+            new TheoryData<string>()
+            {
+                "nonsense",
+                "",
+                null,
+                "42",  // numeric outside the enum range: TryParse accepts it as (JourneyHeuristic)42; the
+                       // Enum.IsDefined guard must reject it so it doesn't silently fall into Shortest.
+            };
+
+        [Theory]
+        [MemberData(nameof(OptimisationStrategyDefaultCheck))]
+        public void StationGroupOptimisationStrategyDefaultsToLongestWhenMissingOrUnparseable(string configValue)
+        {
+            var appSettings = Substitute.For<IConfiguration>();
+            appSettings["StationGroupOptimisationStrategy"].Returns(configValue);
+
+            var config = new Configuration(appSettings, Substitute.For<ILogger>());
+
+            Assert.Equal(JourneyHeuristic.Longest, config.StationGroupOptimisationStrategy);
+        }
     }
 }

--- a/Timetable.Web.Test/ConfigurationTest.cs
+++ b/Timetable.Web.Test/ConfigurationTest.cs
@@ -112,5 +112,34 @@ namespace Timetable.Web.Test
             
             Assert.Equal(expected,  config.DarwinDate);
         }
+
+        [Fact]
+        public void GetStationGroupsFileFromAppSettings()
+        {
+            var appSettings = Substitute.For<IConfiguration>();
+            appSettings["StationGroupsFile"].Returns("station-groups.json");
+
+            var config = new Configuration(appSettings, Substitute.For<ILogger>());
+
+            Assert.Matches(new Regex("station-groups.json$"), config.StationGroupsFile);
+        }
+
+        [Fact]
+        public void StationGroupsFileIsNullWhenNoConfigValue()
+        {
+            var config = new Configuration(Substitute.For<IConfiguration>(), Substitute.For<ILogger>());
+
+            Assert.Null(config.StationGroupsFile);
+        }
+
+        public static TheoryData<string, JourneyHeuristic> OptimisationStrategyCheck =>
+            new TheoryData<string, JourneyHeuristic>()
+            {
+                {"Longest", JourneyHeuristic.Longest},
+                {"Shortest", JourneyHeuristic.Shortest},
+                {"shortest", JourneyHeuristic.Shortest},
+                {"LONGEST", JourneyHeuristic.Longest},
+            };
+
     }
 }

--- a/Timetable.Web.Test/Loaders/DataLoaderIntegrationTest.cs
+++ b/Timetable.Web.Test/Loaders/DataLoaderIntegrationTest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,9 +84,11 @@ namespace Timetable.Web.Test
             return Factory.CreateCifLoader(archive, Substitute.For<ILogger>(), filters);
         }
         
-        private static IDataLoader Create()
+        private static IDataLoader Create(string stationGroupsFile = null)
         {
-            var config = new Configuration(ConfigurationHelper.GetConfiguration(), Substitute.For<ILogger>());
+            var config = new Configuration(
+                ConfigurationHelper.GetConfiguration(stationGroupsFile: stationGroupsFile),
+                Substitute.For<ILogger>());
             return Factory.CreateLoader(config, Substitute.For<ILogger>()).Result;
         }
         
@@ -145,15 +149,68 @@ namespace Timetable.Web.Test
             {
                 Tocs = new TocLookup(Substitute.For<ILogger>()),
                 Locations = new LocationData(
-                    new List<Location>(), 
+                    new List<Location>(),
                     Substitute.For<ILogger>(),
                     Timetable.Test.Data.Filters.Instance)
             };
-            
+
             var loader = await CreateDarwinLoader();
             data = await loader.EnrichReferenceDataAsync(data,  CancellationToken.None);
-            
+
             Assert.NotEmpty(data.Tocs);
+        }
+
+        [Fact]
+        public async Task LoadStationGroupsIsEmptyWhenNoFile()
+        {
+            // The core repo doesn't ship Data/station-groups.json - the wrapper produces it at build time.
+            // The full loader chain should populate data.StationGroups with an empty lookup (not null) and
+            // leave the rest of the data load unaffected, proving the wiring through Factory.CreateLoader
+            // → DataLoader.LoadAsync → StationGroupsLoader → Data.StationGroups end-to-end.
+            var loader = Create();
+            var data = await loader.LoadAsync(CancellationToken.None);
+
+            Assert.NotNull(data.StationGroups);
+            Assert.False(data.StationGroups.TryGet("GB@LO", out _));
+        }
+
+        [Fact]
+        public async Task LoadStationGroupsFromFile()
+        {
+            // Write a station-groups file with real CRS codes that the test CIF (ttis144.zip) contains, then
+            // load it through the full data loader chain. Proves the loader resolves member CRS against the
+            // loaded LocationData and the result lands on Data.StationGroups - the integration of the file-
+            // loaded path that the unit tests cover with mocked locations.
+            //
+            // Priorities are deliberately non-alphabetical so that accidental loss of ordering (e.g. if Priorities
+            // ever switched to a HashSet) shows up here.
+            var path = Path.Combine(Path.GetTempPath(), $"integration-station-groups-{Guid.NewGuid():N}.json");
+            File.WriteAllText(path,
+                @"{ ""groups"": [
+                    { ""code"": ""GB@TEST"",
+                      ""members"": [""EUS"", ""KGX"", ""LST"", ""PAD"", ""WAT""],
+                      ""priorities"": [""WAT"", ""EUS""] }
+                ] }");
+            try
+            {
+                var loader = Create(stationGroupsFile: path);
+                var data = await loader.LoadAsync(CancellationToken.None);
+
+                Assert.True(data.StationGroups.TryGet("GB@TEST", out var group));
+
+                // Members is an unordered set; sort before comparing.
+                var memberCrs = group.Members.Select(s => s.ThreeLetterCode).OrderBy(s => s).ToArray();
+                Assert.Equal(new[] { "EUS", "KGX", "LST", "PAD", "WAT" }, memberCrs);
+
+                // Priorities is an ordered list (first-match-wins); assert the sequence to pin the contract.
+                Assert.NotNull(group.Priorities);
+                Assert.Equal(new[] { "WAT", "EUS" }, group.Priorities.Select(p => p.ThreeLetterCode).ToArray());
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
     }
 }

--- a/Timetable.Web.Test/Loaders/DataLoaderIntegrationTest.cs
+++ b/Timetable.Web.Test/Loaders/DataLoaderIntegrationTest.cs
@@ -182,14 +182,17 @@ namespace Timetable.Web.Test
             // loaded LocationData and the result lands on Data.StationGroups - the integration of the file-
             // loaded path that the unit tests cover with mocked locations.
             //
-            // Priorities are deliberately non-alphabetical so that accidental loss of ordering (e.g. if Priorities
-            // ever switched to a HashSet) shows up here.
+            // Priority entries are deliberately listed in reverse priority order in JSON so that the loader's
+            // sort-by-Priority is observable from the assertion below.
             var path = Path.Combine(Path.GetTempPath(), $"integration-station-groups-{Guid.NewGuid():N}.json");
             File.WriteAllText(path,
                 @"{ ""groups"": [
                     { ""code"": ""GB@TEST"",
                       ""members"": [""EUS"", ""KGX"", ""LST"", ""PAD"", ""WAT""],
-                      ""priorities"": [""WAT"", ""EUS""] }
+                      ""priorities"": [
+                          { ""crs"": ""EUS"", ""priority"": 1 },
+                          { ""crs"": ""WAT"", ""priority"": 0 }
+                      ] }
                 ] }");
             try
             {

--- a/Timetable.Web.Test/Loaders/DataLoaderTest.cs
+++ b/Timetable.Web.Test/Loaders/DataLoaderTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -238,7 +237,7 @@ namespace Timetable.Web.Test
         [Fact]
         public async Task LoadSetsStationGroups()
         {
-            var lookup = new StationGroupLookup(Enumerable.Empty<StationGroup>());
+            var lookup = new StationGroupLookup(new Dictionary<string, StationGroup>());
             var stationGroups = Substitute.For<IStationGroupsLoader>();
             stationGroups.LoadAsync(Arg.Any<ILocationData>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult(lookup));

--- a/Timetable.Web.Test/Loaders/DataLoaderTest.cs
+++ b/Timetable.Web.Test/Loaders/DataLoaderTest.cs
@@ -33,19 +33,22 @@ namespace Timetable.Web.Test
             }
         }
 
-        private Web.Loaders.DataLoader CreateLoader(IArchive archive = null, 
-            ICifParser cifParser = null, 
+        private Web.Loaders.DataLoader CreateLoader(IArchive archive = null,
+            ICifParser cifParser = null,
             IDataEnricher knowledgebase = null,
-            IDataEnricher darwin = null)
+            IDataEnricher darwin = null,
+            IStationGroupsLoader stationGroups = null)
         {
             archive = CreateMockArchive(archive, cifParser);
             darwin ??= new NopLoader();
             knowledgebase ??= new KnowledgebaseLoader(Substitute.For<IKnowledgebaseAsync>(), Substitute.For<ILogger>());
-            
+            stationGroups ??= new StationGroupsLoader(null, Substitute.For<ILogger>());
+
             return Factory.CreateLoader(
-                archive, 
-                darwin, 
-                knowledgebase, 
+                archive,
+                darwin,
+                knowledgebase,
+                stationGroups,
                 Substitute.For<ILogger>(),
                 Timetable.Test.Data.Filters.Instance) as Web.Loaders.DataLoader;
         }
@@ -228,8 +231,22 @@ namespace Timetable.Web.Test
         {
             var loader = CreateLoader();
             var data = await loader.LoadAsync(CancellationToken.None);
-            
+
             Assert.NotNull(data.Tocs);
+        }
+
+        [Fact]
+        public async Task LoadSetsStationGroups()
+        {
+            var lookup = new StationGroupLookup(Enumerable.Empty<StationGroup>());
+            var stationGroups = Substitute.For<IStationGroupsLoader>();
+            stationGroups.LoadAsync(Arg.Any<ILocationData>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(lookup));
+
+            var loader = CreateLoader(stationGroups: stationGroups);
+            var data = await loader.LoadAsync(CancellationToken.None);
+
+            Assert.Same(lookup, data.StationGroups);
         }
     }
 }

--- a/Timetable.Web.Test/Loaders/StationGroupsLoaderTest.cs
+++ b/Timetable.Web.Test/Loaders/StationGroupsLoaderTest.cs
@@ -61,7 +61,7 @@ namespace Timetable.Web.Test.Loaders
         public async Task LoadsGroupsFromValidFile()
         {
             var path = WriteTempFile(@"{ ""groups"": [
-                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV"", ""MCO""], ""priorities"": [""MAN""] },
+                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV"", ""MCO""], ""priorities"": [{ ""crs"": ""MAN"", ""priority"": 0 }] },
                 { ""code"": ""GB#RE"", ""members"": [""RDG"", ""RDW""] }
             ] }");
             var locations = LocationsWith("MAN", "MCV", "MCO", "RDG", "RDW");
@@ -159,7 +159,7 @@ namespace Timetable.Web.Test.Loaders
         {
             var logger = Substitute.For<ILogger>();
             var path = WriteTempFile(@"{ ""groups"": [
-                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV""], ""priorities"": [""MAN"", ""MAN""] }
+                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV""], ""priorities"": [{ ""crs"": ""MAN"", ""priority"": 0 }, { ""crs"": ""MAN"", ""priority"": 1 }] }
             ] }");
             var locations = LocationsWith("MAN", "MCV");
 
@@ -191,7 +191,7 @@ namespace Timetable.Web.Test.Loaders
         {
             var logger = Substitute.For<ILogger>();
             var path = WriteTempFile(@"{ ""groups"": [
-                { ""code"": ""GB@MA"", ""members"": [""MAN""], ""priorities"": [""MAN"", """"] }
+                { ""code"": ""GB@MA"", ""members"": [""MAN""], ""priorities"": [{ ""crs"": ""MAN"", ""priority"": 0 }, { ""crs"": """", ""priority"": 1 }] }
             ] }");
             var locations = LocationsWith("MAN");
 
@@ -261,7 +261,7 @@ namespace Timetable.Web.Test.Loaders
             // skips just the priority; the group survives with its valid members and a null Priorities list.
             var logger = Substitute.For<ILogger>();
             var path = WriteTempFile(@"{ ""groups"": [
-                { ""code"": ""GB@BAD"", ""members"": [""AAA"", ""BBB""], ""priorities"": [""ZZZ""] }
+                { ""code"": ""GB@BAD"", ""members"": [""AAA"", ""BBB""], ""priorities"": [{ ""crs"": ""ZZZ"", ""priority"": 0 }] }
             ] }");
             var locations = LocationsWith("AAA", "BBB", "ZZZ");
 

--- a/Timetable.Web.Test/Loaders/StationGroupsLoaderTest.cs
+++ b/Timetable.Web.Test/Loaders/StationGroupsLoaderTest.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using Serilog;
+using Timetable.Test.Data;
+using Timetable.Web.Loaders;
+using Xunit;
+
+namespace Timetable.Web.Test.Loaders
+{
+    public class StationGroupsLoaderTest : IDisposable
+    {
+        private readonly List<string> _tempFiles = new List<string>();
+
+        private string WriteTempFile(string contents)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"station-groups-{Guid.NewGuid():N}.json");
+            File.WriteAllText(path, contents);
+            _tempFiles.Add(path);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            foreach (var file in _tempFiles)
+                if (File.Exists(file))
+                    File.Delete(file);
+        }
+
+        private static StationGroupsLoader CreateLoader(string path, ILogger logger = null) =>
+            new StationGroupsLoader(path, logger ?? Substitute.For<ILogger>());
+
+        // ILocationData mock that resolves only the supplied CRS codes (to fresh test stations) and rejects
+        // everything else. Lets each test declare exactly which stations its file should be able to resolve.
+        private static ILocationData LocationsWith(params string[] knownCrsCodes)
+        {
+            var locations = Substitute.For<ILocationData>();
+            var known = new HashSet<string>(knownCrsCodes, StringComparer.OrdinalIgnoreCase);
+            locations
+                .TryGetStation(default, out Arg.Any<Station>())
+                .ReturnsForAnyArgs(ci =>
+                {
+                    var crs = (string)ci[0];
+                    if (crs != null && known.Contains(crs))
+                    {
+                        ci[1] = TestStations.Create(crs);
+                        return true;
+                    }
+                    ci[1] = null!;
+                    return false;
+                });
+            return locations;
+        }
+
+        [Fact]
+        public async Task LoadsGroupsFromValidFile()
+        {
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV"", ""MCO""], ""priorities"": [""MAN""] },
+                { ""code"": ""GB#RE"", ""members"": [""RDG"", ""RDW""] }
+            ] }");
+            var locations = LocationsWith("MAN", "MCV", "MCO", "RDG", "RDW");
+
+            var lookup = await CreateLoader(path).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out var manchester).Should().BeTrue();
+            manchester.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("MAN", "MCV", "MCO");
+            manchester.Priorities!.Select(p => p.ThreeLetterCode).Should().Equal("MAN");
+
+            lookup.TryGet("GB#RE", out var reading).Should().BeTrue();
+            reading.Priorities.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task LookupIsCaseInsensitive()
+        {
+            var path = WriteTempFile(@"{ ""groups"": [ { ""code"": ""GB@MA"", ""members"": [""MAN""] } ] }");
+            var locations = LocationsWith("MAN");
+
+            var lookup = await CreateLoader(path).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("gb@ma", out _).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task EmptyGroupsArrayLoadsNoGroups()
+        {
+            var path = WriteTempFile(@"{ ""groups"": [] }");
+
+            var lookup = await CreateLoader(path).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task MissingFileReturnsEmptyLookupAndLogsInformation()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.json");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeFalse();
+            logger.Received().Information(Arg.Is<string>(s => s.Contains("not found")), path);
+        }
+
+        [Fact]
+        public async Task NullPathReturnsEmptyLookup()
+        {
+            var lookup = await CreateLoader(null).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task MalformedFileReturnsEmptyLookupAndLogsError()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ this is not valid json ");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeFalse();
+            logger.Received().Error(Arg.Any<Exception>(), Arg.Is<string>(s => s.Contains("malformed")), path);
+        }
+
+        [Fact]
+        public async Task MissingGroupsKeyLoadsNoGroups()
+        {
+            // Different code path from {"groups":[]}: the JSON has no "groups" property at all.
+            var path = WriteTempFile(@"{}");
+
+            var lookup = await CreateLoader(path).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task LowercaseMemberCrsStillResolves()
+        {
+            // Master station data is uppercase by convention. Loader normalises so a lowercase JSON entry
+            // still resolves rather than appearing as a missing-CRS warning.
+            var path = WriteTempFile(@"{ ""groups"": [ { ""code"": ""GB@MA"", ""members"": [""man""] } ] }");
+            var locations = LocationsWith("MAN");
+
+            var lookup = await CreateLoader(path).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out var group).Should().BeTrue();
+            group.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("MAN");
+        }
+
+        [Fact]
+        public async Task SkipsDuplicatePriorityCrs()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@MA"", ""members"": [""MAN"", ""MCV""], ""priorities"": [""MAN"", ""MAN""] }
+            ] }");
+            var locations = LocationsWith("MAN", "MCV");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out var group).Should().BeTrue();
+            group.Priorities!.Select(p => p.ThreeLetterCode).Should().Equal("MAN");
+            logger.Received().Warning(Arg.Is<string>(s => s.Contains("duplicate priority")), "MAN", "GB@MA");
+        }
+
+        [Fact]
+        public async Task EmptyMemberCrsIsSkippedAndLogged()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@MA"", ""members"": [""MAN"", """", ""MCV""] }
+            ] }");
+            var locations = LocationsWith("MAN", "MCV");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out var group).Should().BeTrue();
+            group.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("MAN", "MCV");
+            logger.Received().Warning(Arg.Is<string>(s => s.Contains("empty member entry")), "GB@MA");
+        }
+
+        [Fact]
+        public async Task EmptyPriorityCrsIsSkippedAndLogged()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@MA"", ""members"": [""MAN""], ""priorities"": [""MAN"", """"] }
+            ] }");
+            var locations = LocationsWith("MAN");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out _).Should().BeTrue();
+            logger.Received().Warning(Arg.Is<string>(s => s.Contains("empty priority entry")), "GB@MA");
+        }
+
+        [Fact]
+        public async Task DuplicateCodeWhereFirstHasNoResolvableMembersDoesNotBlockSecond()
+        {
+            // A second valid entry sharing a code with an earlier dropped one (no resolvable members) still
+            // loads, because dedup runs after member resolution rather than before.
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@LO"", ""members"": [""BOGUS""] },
+                { ""code"": ""GB@LO"", ""members"": [""EUS"", ""KGX""] }
+            ] }");
+            var locations = LocationsWith("EUS", "KGX");
+
+            var lookup = await CreateLoader(path).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@LO", out var group).Should().BeTrue();
+            group.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("EUS", "KGX");
+        }
+
+        [Fact]
+        public async Task SkipsMemberCrsNotInMasterStationData()
+        {
+            // BBB isn't known to ILocationData. Loader skips just that member; the group survives with the rest.
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@PARTIAL"", ""members"": [""AAA"", ""BBB"", ""CCC""] }
+            ] }");
+            var locations = LocationsWith("AAA", "CCC");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@PARTIAL", out var group).Should().BeTrue();
+            group.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("AAA", "CCC");
+            logger.Received().Warning(
+                Arg.Is<string>(s => s.Contains("not found in master station data")), "BBB", "GB@PARTIAL");
+        }
+
+        [Fact]
+        public async Task SkipsGroupWhenNoMembersResolve()
+        {
+            // None of GB@ALL_BAD's members are in master data, so the whole group is dropped. GB@OK still loads.
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@ALL_BAD"", ""members"": [""AAA"", ""BBB""] },
+                { ""code"": ""GB@OK"", ""members"": [""CCC""] }
+            ] }");
+            var locations = LocationsWith("CCC");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@ALL_BAD", out _).Should().BeFalse();
+            lookup.TryGet("GB@OK", out _).Should().BeTrue();
+            logger.Received().Warning(Arg.Is<string>(s => s.Contains("none of its members")), "GB@ALL_BAD");
+        }
+
+        [Fact]
+        public async Task SkipsPriorityCrsNotAmongMembersButKeepsGroup()
+        {
+            // ZZZ is in master station data but isn't a member of GB@BAD (JSON contract violation). Loader
+            // skips just the priority; the group survives with its valid members and a null Priorities list.
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@BAD"", ""members"": [""AAA"", ""BBB""], ""priorities"": [""ZZZ""] }
+            ] }");
+            var locations = LocationsWith("AAA", "BBB", "ZZZ");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@BAD", out var group).Should().BeTrue();
+            group.Priorities.Should().BeNull();
+            logger.Received().Warning(
+                Arg.Is<string>(s => s.Contains("not one of its members")), "ZZZ", "GB@BAD");
+        }
+
+        [Fact]
+        public async Task SkipsGroupWithNoMembersInFile()
+        {
+            var path = WriteTempFile(@"{ ""groups"": [ { ""code"": ""GB@EMPTY"", ""members"": [] } ] }");
+
+            var lookup = await CreateLoader(path).LoadAsync(LocationsWith(), CancellationToken.None);
+
+            lookup.TryGet("GB@EMPTY", out _).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task SkipsDuplicateCodeKeepingTheFirst()
+        {
+            var logger = Substitute.For<ILogger>();
+            var path = WriteTempFile(@"{ ""groups"": [
+                { ""code"": ""GB@MA"", ""members"": [""MAN""] },
+                { ""code"": ""GB@MA"", ""members"": [""MCV""] }
+            ] }");
+            var locations = LocationsWith("MAN", "MCV");
+
+            var lookup = await CreateLoader(path, logger).LoadAsync(locations, CancellationToken.None);
+
+            lookup.TryGet("GB@MA", out var group).Should().BeTrue();
+            group.Members.Select(s => s.ThreeLetterCode).Should().BeEquivalentTo("MAN");
+            logger.Received().Warning(Arg.Is<string>(s => s.Contains("duplicate")), "GB@MA");
+        }
+    }
+}

--- a/Timetable.Web.Test/ServiceConfiguration/SetDataTest.cs
+++ b/Timetable.Web.Test/ServiceConfiguration/SetDataTest.cs
@@ -81,6 +81,15 @@ namespace Timetable.Web.Test.ServiceConfiguration
             var dataDescription = descriptors.Single(d => d.ServiceType.Equals(typeof(Model.Configuration)));
             dataDescription.ImplementationInstance.Should().NotBeNull();
         }
+
+        [Fact]
+        public void AddStationGroups()
+        {
+            var descriptors = ConfigureServices();
+
+            var dataDescription = descriptors.Single(d => d.ServiceType.Equals(typeof(StationGroupLookup)));
+            dataDescription.ImplementationInstance.Should().NotBeNull();
+        }
         
         [Fact]
         public void HasLoadedData()

--- a/Timetable.Web.Test/ServiceConfiguration/SingletonsTest.cs
+++ b/Timetable.Web.Test/ServiceConfiguration/SingletonsTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Serilog;
@@ -12,7 +13,7 @@ namespace Timetable.Web.Test.ServiceConfiguration
 {
     public class SingletonsTest
     {
-        private static List<ServiceDescriptor> ConfigureServices()
+        private static List<ServiceDescriptor> ConfigureServices(string optimisationStrategy = "Longest")
         {
             var descriptors = new List<ServiceDescriptor>();
             var services = Substitute.For<IServiceCollection>();
@@ -20,7 +21,11 @@ namespace Timetable.Web.Test.ServiceConfiguration
                 .Do(args => descriptors.Add(args[0] as ServiceDescriptor));
             var logger = Substitute.For<ILogger>();
 
-            var configure = new Singletons();
+            var appSettings = Substitute.For<IConfiguration>();
+            appSettings["StationGroupOptimisationStrategy"].Returns(optimisationStrategy);
+            var configuration = new Configuration(appSettings, logger);
+
+            var configure = new Singletons(configuration);
             configure.Logger = logger;
             configure.ConfigureServices(services);
             return descriptors;
@@ -41,6 +46,17 @@ namespace Timetable.Web.Test.ServiceConfiguration
             var descriptors = ConfigureServices();
 
             descriptors.Should().Contain(d => d.ServiceType.Equals(typeof(IMapper)));
+        }
+
+        [Theory]
+        [InlineData("Longest")]
+        [InlineData("Shortest")]
+        public void AddStationGroupStopOptimiserToDIContainer(string optimisationStrategy)
+        {
+            var descriptors = ConfigureServices(optimisationStrategy);
+
+            var optimiserDescriptor = descriptors.Single(d => d.ServiceType.Equals(typeof(IStationGroupStopOptimiser)));
+            optimiserDescriptor.ImplementationInstance.Should().BeOfType<StationGroupStopOptimiser>();
         }
     }
 }

--- a/Timetable.Web/Configuration.cs
+++ b/Timetable.Web/Configuration.cs
@@ -75,5 +75,27 @@ namespace Timetable.Web
             }
         }
 
+        /// <summary>
+        /// Full path to the optional station-groups reference file. Null when the key is unset, in which case
+        /// station group search is disabled (the loader treats a missing path the same as a missing file).
+        /// </summary>
+        public string? StationGroupsFile
+        {
+            get
+            {
+                var fileName = _config["StationGroupsFile"];
+                
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    _logger.Debug("Config StationGroupsFile: <not set>");
+                    return null;
+                }
+
+                var path = Path.Combine(DataDirectory, fileName);
+                _logger.Debug("Config StationGroupsFile: {path}", path);
+                
+                return new FileInfo(path).FullName;
+            }
+        }
     }
 }

--- a/Timetable.Web/Configuration.cs
+++ b/Timetable.Web/Configuration.cs
@@ -87,7 +87,7 @@ namespace Timetable.Web
                 
                 if (string.IsNullOrEmpty(fileName))
                 {
-                    _logger.Debug("Config StationGroupsFile: <not set>");
+                    _logger.Information("Config StationGroupsFile: <not set>");
                     return null;
                 }
 

--- a/Timetable.Web/Configuration.cs
+++ b/Timetable.Web/Configuration.cs
@@ -97,5 +97,38 @@ namespace Timetable.Web
                 return new FileInfo(path).FullName;
             }
         }
+
+        /// <summary>
+        /// The journey heuristic the station-group optimiser uses when a service calls at several members of a
+        /// group. Defaults to <see cref="JourneyHeuristic.Longest"/> when unset or unrecognised.
+        /// </summary>
+        public JourneyHeuristic StationGroupOptimisationStrategy
+        {
+            get
+            {
+                var configValue = _config["StationGroupOptimisationStrategy"];
+                
+                // Enum.TryParse alone accepts integers outside the defined range (e.g. "42" becomes
+                // (JourneyHeuristic)42, which silently falls into the Shortest branch in the optimiser).
+                // Guard with Enum.IsDefined so only named values pass through.
+                if (!string.IsNullOrEmpty(configValue) &&
+                    Enum.TryParse<JourneyHeuristic>(configValue, ignoreCase: true, out var heuristic) &&
+                    Enum.IsDefined(typeof(JourneyHeuristic), heuristic)) {
+                    _logger.Debug("Config StationGroupOptimisationStrategy: {configValue}", configValue);
+                    return heuristic;
+                }
+
+                if (string.IsNullOrEmpty(configValue))
+                    _logger.Information(
+                        "StationGroupOptimisationStrategy not set; defaulting to {Default}",
+                        JourneyHeuristic.Longest);
+                else
+                    _logger.Warning(
+                        "StationGroupOptimisationStrategy '{configValue}' not recognised; defaulting to {Default}",
+                        configValue, JourneyHeuristic.Longest);
+
+                return JourneyHeuristic.Longest;
+            }
+        }
     }
 }

--- a/Timetable.Web/ConfigurationFinder.cs
+++ b/Timetable.Web/ConfigurationFinder.cs
@@ -37,7 +37,7 @@ namespace Timetable.Web
                 var loader = Factory.CreateLoader(config, logger).Result;
                 var addData = new SetData(loader, logger);
                 
-                configurations.Add(new Singletons());
+                configurations.Add(new Singletons(config));
                 configurations.Add(addData);
                 if(config.EnablePrometheusMonitoring)
                     configurations.Add(new ServiceConfiguration.Prometheus());

--- a/Timetable.Web/Factory.cs
+++ b/Timetable.Web/Factory.cs
@@ -63,7 +63,13 @@ namespace Timetable.Web
             var darwin = await CreateDarwinLoader(config, logger);
             var knowledgebase = CreateKnowledgebase(config, logger);
             var filters = CreateFilters(config, logger);
-            return CreateLoader(archive, darwin, knowledgebase, logger, filters);
+            var stationGroups = CreateStationGroupsLoader(config, logger);
+            return CreateLoader(archive, darwin, knowledgebase, stationGroups, logger, filters);
+        }
+
+        internal static IStationGroupsLoader CreateStationGroupsLoader(Configuration config, ILogger logger)
+        {
+            return new StationGroupsLoader(config.StationGroupsFile, logger.ForContext<StationGroupsLoader>());
         }
 
         internal static ServiceFilters CreateFilters(Configuration config, ILogger logger)
@@ -71,10 +77,10 @@ namespace Timetable.Web
             return new ServiceFilters(config.EnableDebugResponses, logger);
         }
         
-        internal static IDataLoader CreateLoader(IArchive archive, IDataEnricher darwin, IDataEnricher knowledgebase, ILogger logger, ServiceFilters filters)
+        internal static IDataLoader CreateLoader(IArchive archive, IDataEnricher darwin, IDataEnricher knowledgebase, IStationGroupsLoader stationGroups, ILogger logger, ServiceFilters filters)
         {
             var cifLoader = CreateCifLoader(archive, logger, filters);
-            return new Loaders.DataLoader(cifLoader, darwin, knowledgebase, logger);
+            return new Loaders.DataLoader(cifLoader, darwin, knowledgebase, stationGroups, logger);
         }
         
         internal static CifLoader CreateCifLoader(IArchive archive, ILogger logger, ServiceFilters filters)

--- a/Timetable.Web/Loaders/DataLoader.cs
+++ b/Timetable.Web/Loaders/DataLoader.cs
@@ -12,24 +12,28 @@ namespace Timetable.Web.Loaders
         private readonly ICifLoader _cif;
         private readonly IDataEnricher _darwin;
         private readonly IDataEnricher _knowledgebase;
+        private readonly IStationGroupsLoader _stationGroups;
         private readonly ILogger _logger;
 
-        public DataLoader(ICifLoader cif, IDataEnricher darwin, IDataEnricher knowledgebase, ILogger logger)
+        public DataLoader(ICifLoader cif, IDataEnricher darwin, IDataEnricher knowledgebase, IStationGroupsLoader stationGroups, ILogger logger)
         {
             _cif = cif;
             _darwin = darwin;
             _knowledgebase = knowledgebase;
+            _stationGroups = stationGroups;
             _logger = logger;
         }
        
         public async Task<Data> LoadAsync(CancellationToken token)
         {
             var tocs = new TocLookup(_logger);
+            var locations = await LoadLocationsAsync(tocs, token).ConfigureAwait(false);
             Data data = new Data()
             {
                 Archive = _cif.ArchiveFile,
                 Tocs = tocs,
-                Locations = await LoadLocationsAsync(tocs, token).ConfigureAwait(false)
+                Locations = locations,
+                StationGroups = await _stationGroups.LoadAsync(locations, token).ConfigureAwait(false)
             };
 
             var enrichRefDataTask = Task.Run(async () =>

--- a/Timetable.Web/Loaders/IStationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/IStationGroupsLoader.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Timetable.Web.Loaders
+{
+    /// <summary>
+    /// Loads the station-group reference data from disk at startup and exposes it as a
+    /// <see cref="StationGroupLookup"/>. The file is optional: when it is absent the loader
+    /// returns an empty lookup so that group lookups simply fail and the feature is disabled.
+    /// </summary>
+    /// <remarks>
+    /// Member and priority CRS codes in the file are resolved to <see cref="Station"/> instances via
+    /// <paramref name="locations"/>: each <see cref="StationGroup"/> holds the resolved instances. A CRS
+    /// that doesn't appear in the master station data is logged and skipped; a group with no resolvable
+    /// members is dropped entirely.
+    /// </remarks>
+    public interface IStationGroupsLoader
+    {
+        /// <summary>
+        /// Reads and validates the station-groups file, resolving CRS codes against
+        /// <paramref name="locations"/> and returning a populated <see cref="StationGroupLookup"/>.
+        /// Invalid entries are skipped with a warning; a malformed file throws.
+        /// </summary>
+        Task<StationGroupLookup> LoadAsync(ILocationData locations, CancellationToken token);
+    }
+}

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -71,13 +71,13 @@ namespace Timetable.Web.Loaders
             }
         }
 
-        private IReadOnlyList<StationGroup> BuildGroups(IReadOnlyList<StationGroupJsonDefinition>? definitions, ILocationData locations, LoadReport report)
+        private IReadOnlyDictionary<string, StationGroup> BuildGroups(
+            IReadOnlyList<StationGroupJsonDefinition>? definitions, ILocationData locations, LoadReport report)
         {
-            var groups = new List<StationGroup>();
+            var groups = new Dictionary<string, StationGroup>(StringComparer.OrdinalIgnoreCase);
             if (definitions == null)
                 return groups;
 
-            var seenCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var definition in definitions)
             {
                 var members = ResolveMembers(definition.Members, locations, definition.Code, report);
@@ -92,20 +92,21 @@ namespace Timetable.Web.Loaders
 
                 // Dedup AFTER member resolution: a valid second entry shouldn't be rejected as a "duplicate"
                 // of an earlier entry that itself got dropped for having no resolvable members.
-                if (!string.IsNullOrEmpty(definition.Code) && !seenCodes.Add(definition.Code))
+                if (!string.IsNullOrEmpty(definition.Code) && groups.ContainsKey(definition.Code))
                 {
                     _logger.Warning("Skipping duplicate station group code {Code}", definition.Code);
                     report.GroupsSkipped++;
                     continue;
                 }
-                
+
                 var priorities = definition.Priorities is { Count: > 0 }
                     ? ResolvePriorities(definition.Priorities, members, definition.Code, report)
                     : null;
 
                 try
                 {
-                    groups.Add(new StationGroup(definition.Code, members, priorities));
+                    var group = new StationGroup(definition.Code, members, priorities);
+                    groups.Add(group.Code, group);
                 }
                 catch (ArgumentException e)
                 {
@@ -189,7 +190,8 @@ namespace Timetable.Web.Loaders
             return resolved;
         }
 
-        private static StationGroupLookup Empty() => new StationGroupLookup(Array.Empty<StationGroup>());
+        private static StationGroupLookup Empty() =>
+            new StationGroupLookup(new Dictionary<string, StationGroup>(StringComparer.OrdinalIgnoreCase));
 
         private sealed class StationGroupsFile
         {

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -38,14 +38,13 @@ namespace Timetable.Web.Loaders
         {
             if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath))
             {
-                _logger.Information(
-                    "station-groups file not found at {Path} - station group search disabled", _filePath);
+                _logger.Information("station-groups file not found at {Path} - station group search disabled", _filePath);
                 return Empty();
             }
 
             var file = await ReadFileAsync(_filePath, token).ConfigureAwait(false);
             if (file == null)
-                return Empty(); // ReadFileAsync already logged the malformed-file error.
+                return Empty();
 
             var report = new LoadReport();
             var groups = BuildGroups(file.Groups, locations, report);
@@ -72,8 +71,7 @@ namespace Timetable.Web.Loaders
             }
         }
 
-        private IReadOnlyList<StationGroup> BuildGroups(
-            IReadOnlyList<StationGroupJsonDefinition>? definitions, ILocationData locations, LoadReport report)
+        private IReadOnlyList<StationGroup> BuildGroups(IReadOnlyList<StationGroupJsonDefinition>? definitions, ILocationData locations, LoadReport report)
         {
             var groups = new List<StationGroup>();
             if (definitions == null)
@@ -100,10 +98,7 @@ namespace Timetable.Web.Loaders
                     report.GroupsSkipped++;
                     continue;
                 }
-
-                // Priorities are a subset of members by file contract, so look them up against the
-                // already-resolved members rather than via locations again. A priority CRS that isn't one of
-                // the resolved members is treated as a JSON typo and skipped with a warning.
+                
                 var priorities = definition.Priorities is { Count: > 0 }
                     ? ResolvePriorities(definition.Priorities, members, definition.Code, report)
                     : null;
@@ -154,8 +149,8 @@ namespace Timetable.Web.Loaders
             return resolved;
         }
 
-        // Resolves priority CRS codes against the already-resolved members. A priority that isn't one of the
-        // members (or that duplicates one already added) is skipped with a warning.
+        // Resolves priority CRS codes against the already-resolved members because by contract they should be a subset.
+        // A priority that isn't one of the members (or that duplicates one already added) is skipped with a warning.
         private List<Station> ResolvePriorities(
             IReadOnlyList<string> priorityCodes, IReadOnlyList<Station> members, string groupCode, LoadReport report)
         {
@@ -171,6 +166,7 @@ namespace Timetable.Web.Loaders
                 }
                 var member = members.FirstOrDefault(m =>
                     StringComparer.OrdinalIgnoreCase.Equals(m.ThreeLetterCode, crs));
+                
                 if (member == null)
                 {
                     _logger.Warning(
@@ -179,6 +175,7 @@ namespace Timetable.Web.Loaders
                     report.PrioritiesSkipped++;
                     continue;
                 }
+                
                 if (!seen.Add(member))
                 {
                     _logger.Warning(

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -156,7 +156,6 @@ namespace Timetable.Web.Loaders
             IReadOnlyList<string> priorityCodes, IReadOnlyList<Station> members, string groupCode, LoadReport report)
         {
             var resolved = new List<Station>();
-            var seen = new HashSet<Station>();
             foreach (var crs in priorityCodes)
             {
                 if (string.IsNullOrEmpty(crs))
@@ -167,7 +166,7 @@ namespace Timetable.Web.Loaders
                 }
                 var member = members.FirstOrDefault(m =>
                     StringComparer.OrdinalIgnoreCase.Equals(m.ThreeLetterCode, crs));
-                
+
                 if (member == null)
                 {
                     _logger.Warning(
@@ -177,7 +176,7 @@ namespace Timetable.Web.Loaders
                     continue;
                 }
                 
-                if (!seen.Add(member))
+                if (resolved.Contains(member))
                 {
                     _logger.Warning(
                         "Skipping duplicate priority {Crs} of station group {Code}",

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Timetable.Web.Loaders
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads a small vendor-neutral JSON file of the shape
+    /// <c>{ "groups": [ { "code": "GB@LO", "members": ["EUS","KGX"], "priorities": ["EUS"] } ] }</c>.
+    /// All failure modes degrade gracefully (consistent with the other optional reference-data loaders):
+    /// an absent or malformed file disables the feature with a single log line, and a single invalid group,
+    /// member or priority is skipped with a warning rather than taking the rest of the file down. A summary
+    /// line at the end of a successful load reports the totals so partial-deploy issues are alertable.
+    /// </remarks>
+    public class StationGroupsLoader : IStationGroupsLoader
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly string? _filePath;
+        private readonly ILogger _logger;
+
+        public StationGroupsLoader(string? filePath, ILogger logger)
+        {
+            _filePath = filePath;
+            _logger = logger;
+        }
+
+        public async Task<StationGroupLookup> LoadAsync(ILocationData locations, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath))
+            {
+                _logger.Information(
+                    "station-groups file not found at {Path} - station group search disabled", _filePath);
+                return Empty();
+            }
+
+            var file = await ReadFileAsync(_filePath, token).ConfigureAwait(false);
+            if (file == null)
+                return Empty(); // ReadFileAsync already logged the malformed-file error.
+
+            var report = new LoadReport();
+            var groups = BuildGroups(file.Groups, locations, report);
+
+            _logger.Information(
+                "Loaded {Count} station groups from {Path} " +
+                "(skipped {GroupsSkipped} group(s), {MembersSkipped} member(s), {PrioritiesSkipped} priorities)",
+                groups.Count, _filePath, report.GroupsSkipped, report.MembersSkipped, report.PrioritiesSkipped);
+
+            return new StationGroupLookup(groups);
+        }
+
+        private async Task<StationGroupsFile?> ReadFileAsync(string path, CancellationToken token)
+        {
+            try
+            {
+                var json = await File.ReadAllTextAsync(path, token).ConfigureAwait(false);
+                return JsonSerializer.Deserialize<StationGroupsFile>(json, SerializerOptions);
+            }
+            catch (JsonException e)
+            {
+                _logger.Error(e, "station-groups file at {Path} is malformed - station group search disabled", path);
+                return null;
+            }
+        }
+
+        private IReadOnlyList<StationGroup> BuildGroups(
+            IReadOnlyList<StationGroupJsonDefinition>? definitions, ILocationData locations, LoadReport report)
+        {
+            var groups = new List<StationGroup>();
+            if (definitions == null)
+                return groups;
+
+            var seenCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var definition in definitions)
+            {
+                var members = ResolveMembers(definition.Members, locations, definition.Code, report);
+                if (members.Count == 0)
+                {
+                    _logger.Warning(
+                        "Skipping station group {Code} - none of its members were found in master station data",
+                        definition.Code);
+                    report.GroupsSkipped++;
+                    continue;
+                }
+
+                // Dedup AFTER member resolution: a valid second entry shouldn't be rejected as a "duplicate"
+                // of an earlier entry that itself got dropped for having no resolvable members.
+                if (!string.IsNullOrEmpty(definition.Code) && !seenCodes.Add(definition.Code))
+                {
+                    _logger.Warning("Skipping duplicate station group code {Code}", definition.Code);
+                    report.GroupsSkipped++;
+                    continue;
+                }
+
+                // Priorities are a subset of members by file contract, so look them up against the
+                // already-resolved members rather than via locations again. A priority CRS that isn't one of
+                // the resolved members is treated as a JSON typo and skipped with a warning.
+                var priorities = definition.Priorities is { Count: > 0 }
+                    ? ResolvePriorities(definition.Priorities, members, definition.Code, report)
+                    : null;
+
+                try
+                {
+                    groups.Add(new StationGroup(definition.Code, members, priorities));
+                }
+                catch (ArgumentException e)
+                {
+                    // Belt-and-braces: catches any remaining StationGroup ctor validation (e.g. empty code)
+                    // so one bad entry is a skip, not a crash.
+                    _logger.Warning(e, "Skipping invalid station group {Code}", definition.Code);
+                    report.GroupsSkipped++;
+                }
+            }
+
+            return groups;
+        }
+
+        // Resolves member CRS codes to Stations via the master station data. CRS not in the data, and empty
+        // entries, are logged and skipped - the caller decides whether the remaining set is sufficient.
+        private List<Station> ResolveMembers(
+            IReadOnlyList<string>? memberCodes, ILocationData locations, string groupCode, LoadReport report)
+        {
+            var resolved = new List<Station>();
+            if (memberCodes == null)
+                return resolved;
+            foreach (var crs in memberCodes)
+            {
+                if (string.IsNullOrEmpty(crs))
+                {
+                    _logger.Warning("Skipping empty member entry in station group {Code}", groupCode);
+                    report.MembersSkipped++;
+                    continue;
+                }
+                
+                if (locations.TryGetStation(crs.ToUpperInvariant(), out var station))
+                    resolved.Add(station);
+                else
+                {
+                    _logger.Warning(
+                        "Skipping member {Crs} of station group {Code} - not found in master station data",
+                        crs, groupCode);
+                    report.MembersSkipped++;
+                }
+            }
+            return resolved;
+        }
+
+        // Resolves priority CRS codes against the already-resolved members. A priority that isn't one of the
+        // members (or that duplicates one already added) is skipped with a warning.
+        private List<Station> ResolvePriorities(
+            IReadOnlyList<string> priorityCodes, IReadOnlyList<Station> members, string groupCode, LoadReport report)
+        {
+            var resolved = new List<Station>();
+            var seen = new HashSet<Station>();
+            foreach (var crs in priorityCodes)
+            {
+                if (string.IsNullOrEmpty(crs))
+                {
+                    _logger.Warning("Skipping empty priority entry in station group {Code}", groupCode);
+                    report.PrioritiesSkipped++;
+                    continue;
+                }
+                var member = members.FirstOrDefault(m =>
+                    StringComparer.OrdinalIgnoreCase.Equals(m.ThreeLetterCode, crs));
+                if (member == null)
+                {
+                    _logger.Warning(
+                        "Skipping priority {Crs} of station group {Code} - not one of its members",
+                        crs, groupCode);
+                    report.PrioritiesSkipped++;
+                    continue;
+                }
+                if (!seen.Add(member))
+                {
+                    _logger.Warning(
+                        "Skipping duplicate priority {Crs} of station group {Code}",
+                        crs, groupCode);
+                    report.PrioritiesSkipped++;
+                    continue;
+                }
+                resolved.Add(member);
+            }
+            return resolved;
+        }
+
+        private static StationGroupLookup Empty() => new StationGroupLookup(Array.Empty<StationGroup>());
+
+        private sealed class StationGroupsFile
+        {
+            public List<StationGroupJsonDefinition>? Groups { get; set; }
+        }
+
+        private sealed class StationGroupJsonDefinition
+        {
+            public string Code { get; set; } = string.Empty;
+            public List<string>? Members { get; set; }
+            public List<string>? Priorities { get; set; }
+        }
+
+        private sealed class LoadReport
+        {
+            public int GroupsSkipped;
+            public int MembersSkipped;
+            public int PrioritiesSkipped;
+        }
+    }
+}

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -42,8 +42,8 @@ namespace Timetable.Web.Loaders
                 return Empty();
             }
 
-            var file = await ReadFileAsync(_filePath, token).ConfigureAwait(false);
-            if (file == null)
+            var (success, file) = await TryReadFileAsync(_filePath, token).ConfigureAwait(false);
+            if (!success || file == null)
                 return Empty();
 
             var report = new LoadReport();
@@ -56,18 +56,19 @@ namespace Timetable.Web.Loaders
 
             return new StationGroupLookup(groups);
         }
-
-        private async Task<StationGroupsFile?> ReadFileAsync(string path, CancellationToken token)
+        
+        private async Task<(bool success, StationGroupsFile? file)> TryReadFileAsync(string path, CancellationToken token)
         {
             try
             {
                 var json = await File.ReadAllTextAsync(path, token).ConfigureAwait(false);
-                return JsonSerializer.Deserialize<StationGroupsFile>(json, SerializerOptions);
+                var file = JsonSerializer.Deserialize<StationGroupsFile>(json, SerializerOptions);
+                return (file != null, file);
             }
             catch (JsonException e)
             {
                 _logger.Error(e, "station-groups file at {Path} is malformed - station group search disabled", path);
-                return null;
+                return (false, null);
             }
         }
 

--- a/Timetable.Web/Loaders/StationGroupsLoader.cs
+++ b/Timetable.Web/Loaders/StationGroupsLoader.cs
@@ -12,7 +12,7 @@ namespace Timetable.Web.Loaders
     /// <inheritdoc />
     /// <remarks>
     /// Reads a small vendor-neutral JSON file of the shape
-    /// <c>{ "groups": [ { "code": "GB@LO", "members": ["EUS","KGX"], "priorities": ["EUS"] } ] }</c>.
+    /// <c>{ "groups": [ { "code": "GB@LO", "members": ["EUS","KGX"], "priorities": [{ "crs": "EUS", "priority": 0 }] } ] }</c>.
     /// All failure modes degrade gracefully (consistent with the other optional reference-data loaders):
     /// an absent or malformed file disables the feature with a single log line, and a single invalid group,
     /// member or priority is skipped with a warning rather than taking the rest of the file down. A summary
@@ -153,35 +153,36 @@ namespace Timetable.Web.Loaders
 
         // Resolves priority CRS codes against the already-resolved members because by contract they should be a subset.
         // A priority that isn't one of the members (or that duplicates one already added) is skipped with a warning.
+        // Entries are sorted by their explicit Priority field so the returned list is in preference order.
         private List<Station> ResolvePriorities(
-            IReadOnlyList<string> priorityCodes, IReadOnlyList<Station> members, string groupCode, LoadReport report)
+            IReadOnlyList<PriorityJsonEntry> priorityEntries, IReadOnlyList<Station> members, string groupCode, LoadReport report)
         {
             var resolved = new List<Station>();
-            foreach (var crs in priorityCodes)
+            foreach (var entry in priorityEntries.OrderBy(e => e.Priority))
             {
-                if (string.IsNullOrEmpty(crs))
+                if (string.IsNullOrEmpty(entry.Crs))
                 {
                     _logger.Warning("Skipping empty priority entry in station group {Code}", groupCode);
                     report.PrioritiesSkipped++;
                     continue;
                 }
                 var member = members.FirstOrDefault(m =>
-                    StringComparer.OrdinalIgnoreCase.Equals(m.ThreeLetterCode, crs));
+                    StringComparer.OrdinalIgnoreCase.Equals(m.ThreeLetterCode, entry.Crs));
 
                 if (member == null)
                 {
                     _logger.Warning(
                         "Skipping priority {Crs} of station group {Code} - not one of its members",
-                        crs, groupCode);
+                        entry.Crs, groupCode);
                     report.PrioritiesSkipped++;
                     continue;
                 }
-                
+
                 if (resolved.Contains(member))
                 {
                     _logger.Warning(
                         "Skipping duplicate priority {Crs} of station group {Code}",
-                        crs, groupCode);
+                        entry.Crs, groupCode);
                     report.PrioritiesSkipped++;
                     continue;
                 }
@@ -202,7 +203,13 @@ namespace Timetable.Web.Loaders
         {
             public string Code { get; set; } = string.Empty;
             public List<string>? Members { get; set; }
-            public List<string>? Priorities { get; set; }
+            public List<PriorityJsonEntry>? Priorities { get; set; }
+        }
+
+        private sealed class PriorityJsonEntry
+        {
+            public string Crs { get; set; } = string.Empty;
+            public int Priority { get; set; }
         }
 
         private sealed class LoadReport

--- a/Timetable.Web/ServiceConfiguration/SetData.cs
+++ b/Timetable.Web/ServiceConfiguration/SetData.cs
@@ -34,6 +34,7 @@ namespace Timetable.Web.ServiceConfiguration
                 .AddSingleton<ILocationData>(data.Locations)
                 .AddSingleton<ITimetableLookup>(data.Timetable)
                 .AddSingleton<Timetable.Data>(data)
+                .AddSingleton<StationGroupLookup>(data.StationGroups)
                 .AddSingleton<Model.Configuration>(Factory.CreateConfigurationResponse(data.Archive));
         }
 

--- a/Timetable.Web/ServiceConfiguration/Singletons.cs
+++ b/Timetable.Web/ServiceConfiguration/Singletons.cs
@@ -11,12 +11,24 @@ namespace Timetable.Web.ServiceConfiguration
 {
     internal class Singletons : IPlugin
     {
+        private readonly Configuration _config;
+
+        public Singletons(Configuration config)
+        {
+            _config = config;
+        }
+
         public ILogger Logger { get; set; }
-        
+
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IFilterFactory>(new GatherFilterFactory(Logger));
-            
+
+            var heuristic = _config.StationGroupOptimisationStrategy;
+            var selector = new CanonicalStopSelector(heuristic);
+            services.AddSingleton<IStationGroupStopOptimiser>(new StationGroupStopOptimiser(selector, Logger));
+            Logger.Information("Registered station group stop optimiser using the {Heuristic} journey heuristic", heuristic);
+
             var mapperConfiguration = new MapperConfiguration(
                 cfg => {
                     cfg.AddProfile<ToViewModelProfile>();

--- a/Timetable.Web/appsettings.json
+++ b/Timetable.Web/appsettings.json
@@ -19,4 +19,5 @@
   "EnablePrometheusMonitoring" : "true",
   "EnableDebugResponses" : "false",
   "StationGroupsFile" : "station-groups.json",
+  "StationGroupOptimisationStrategy" : "Longest"
 }

--- a/Timetable.Web/appsettings.json
+++ b/Timetable.Web/appsettings.json
@@ -17,5 +17,6 @@
   "TocKnowledgebase" : "tocs.xml",
   "EnableCustomPlugins" : "false",
   "EnablePrometheusMonitoring" : "true",
-  "EnableDebugResponses" : "false"
+  "EnableDebugResponses" : "false",
+  "StationGroupsFile" : "station-groups.json",
 }

--- a/Timetable/CanonicalStopSelector.cs
+++ b/Timetable/CanonicalStopSelector.cs
@@ -70,8 +70,8 @@ namespace Timetable
                 candidate.OverrideFoundToStop(stop);
         }
 
-        // Priorities are guaranteed in-group by the StationGroup constructor, so a matched stop is always a
-        // member; no membership re-check is needed here.
+        // Priorities are guaranteed in-group by the loader, so a matched stop is always a member;
+        // no membership re-check is needed here.
         private static ResolvedStop? FindDeparturesDestinationByPriority(
             ResolvedServiceStop candidate,
             IReadOnlyList<Station>? priorities)
@@ -130,8 +130,8 @@ namespace Timetable
                 candidate.OverrideFoundFromStop(stop);
         }
 
-        // Priorities are guaranteed in-group by the StationGroup constructor, so a matched stop is always a
-        // member; no membership re-check is needed here.
+        // Priorities are guaranteed in-group by the loader, so a matched stop is always a member;
+        // no membership re-check is needed here.
         private static ResolvedStop? FindArrivalsOriginByPriority(
             ResolvedServiceStop candidate,
             IReadOnlyList<Station>? priorities)

--- a/Timetable/Data.cs
+++ b/Timetable/Data.cs
@@ -11,7 +11,11 @@ namespace Timetable
         
         public RealtimeData Darwin { get; set; }
 
-        public bool IsLoaded => (Locations?.IsLoaded ?? false) 
+        // Optional station-group reference data. Defaults to an empty lookup so the feature is simply
+        // inert (group lookups return false) when the file is absent, rather than the property being null.
+        public StationGroupLookup StationGroups { get; set; } = new (Enumerable.Empty<StationGroup>());
+
+        public bool IsLoaded => (Locations?.IsLoaded ?? false)
             && (Timetable?.IsLoaded ?? false);
     }
 }

--- a/Timetable/Data.cs
+++ b/Timetable/Data.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Collections.Generic;
 
 namespace Timetable
 {
@@ -8,12 +8,12 @@ namespace Timetable
         public ILocationData Locations { get; set; }
         public ITimetableLookup Timetable { get; set; }
         public ITocLookup Tocs { get; set; }
-        
+
         public RealtimeData Darwin { get; set; }
 
         // Optional station-group reference data. Defaults to an empty lookup so the feature is simply
         // inert (group lookups return false) when the file is absent, rather than the property being null.
-        public StationGroupLookup StationGroups { get; set; } = new (Enumerable.Empty<StationGroup>());
+        public StationGroupLookup StationGroups { get; set; } = new (new Dictionary<string, StationGroup>());
 
         public bool IsLoaded => (Locations?.IsLoaded ?? false)
             && (Timetable?.IsLoaded ?? false);

--- a/Timetable/StationGroup.cs
+++ b/Timetable/StationGroup.cs
@@ -34,14 +34,6 @@ namespace Timetable
                 throw new ArgumentException($"Group {code} must have at least one member", nameof(members));
 
             Priorities = priorities is { Count: > 0 } ? priorities : null;
-
-            // Priorities must be a subset of Members. Enforcing it here means the optimiser can trust that a
-            // priority station is always in-group, so it never needs to re-check membership when overriding stops.
-            if (Priorities != null)
-                foreach (var priority in Priorities)
-                    if (!Members.Contains(priority))
-                        throw new ArgumentException(
-                            $"Group {code} priority '{priority}' is not one of its members", nameof(priorities));
         }
     }
 }

--- a/Timetable/StationGroup.cs
+++ b/Timetable/StationGroup.cs
@@ -7,13 +7,8 @@ namespace Timetable
     /// A named group of stations sharing a common code (e.g. <c>GB@LO</c> for "London (all)").
     /// The optional <see cref="Priorities"/> list defines a strict preference ordering used by the
     /// station-group optimiser when compiling search results; if null, the optimiser falls back to its
-    /// configured <see cref="JourneyHeuristic"/>.
+    /// configured <see cref="JourneyHeuristic"/>. The list is supplied in priority order by the loader.
     /// </summary>
-    /// <remarks>
-    /// Members and priorities are <see cref="Station"/>s rather than CRS strings: stations are created exactly
-    /// once in the master location data, so holding the resolved instances lets the optimiser compare stops by
-    /// station identity and avoids re-resolving codes on every comparison.
-    /// </remarks>
     public class StationGroup
     {
         public string Code { get; }

--- a/Timetable/StationGroupLookup.cs
+++ b/Timetable/StationGroupLookup.cs
@@ -5,32 +5,24 @@ using System.Diagnostics.CodeAnalysis;
 namespace Timetable
 {
     /// <summary>
-    /// Maintains an in-memory IReadOnlyDictionary of known <see cref="StationGroup"/>s.
+    /// Maintains an in-memory dictionary of known <see cref="StationGroup"/>s, keyed by group code.
     /// Provides a lookup method to retrieve a single <see cref="StationGroup"/> by code.
     /// </summary>
+    /// <remarks>
+    /// Case-sensitivity follows the comparer the supplied dictionary was built with. The production
+    /// builder (<c>StationGroupsLoader</c>) uses <see cref="StringComparer.OrdinalIgnoreCase"/>.
+    /// </remarks>
     public class StationGroupLookup
     {
         private readonly IReadOnlyDictionary<string, StationGroup> _groups;
 
-        public StationGroupLookup(IEnumerable<StationGroup> groups)
+        public StationGroupLookup(IReadOnlyDictionary<string, StationGroup> groups)
         {
-            if (groups == null)
-                throw new ArgumentNullException(nameof(groups));
-
-            var map = new Dictionary<string, StationGroup>(StringComparer.OrdinalIgnoreCase);
-            foreach (var group in groups)
-            {
-                if (map.ContainsKey(group.Code))
-                    throw new ArgumentException($"Duplicate group code: {group.Code}", nameof(groups));
-                map.Add(group.Code, group);
-            }
-
-            _groups = map;
+            _groups = groups ?? throw new ArgumentNullException(nameof(groups));
         }
 
         /// <summary>
-        /// Attempts to look up a <see cref="StationGroup"/> by its group code.
-        /// Lookup is case-insensitive and unknown codes return false.
+        /// Attempts to look up a <see cref="StationGroup"/> by its group code. Unknown codes return false.
         /// </summary>
         /// <param name="code">Station group code (e.g. <c>GB@LO</c>)</param>
         /// <param name="group">The resulting <see cref="StationGroup"/> from the dictionary</param>


### PR DESCRIPTION
This PR implements phase 2 of Claude's plan (found [here](https://github.com/Phils0/UkTimetableService/blob/main/docs/plans/2026-05-26-station-group-search-plan.md)) for adding station group search support.

The scope of this PR is to:
- Add a new loader that runs at startup, with the responsibility of loading station groups into memory from a reference file.
  - the groups are read from a file in the /Data directory at startup. This matches the pattern for loading other data files.
  - if no file path or file is provided or if the file is malformed, the station groups feature is effectively disabled and the service continues to start up
  - group members and their priorities are verified against LocationsData to ensure they're real stations. Duplicates are dropped. Priorities are also checked to ensure they're a subset of Members (the existing constructor check for this will be dropped in a separate commit)
  - a log summary of the load is recorded so it's easy to see how many groups were loaded, which groups were skipped entirely, and which had priorities or members skipped
- Make the journey heuristic used by the station group stop optimiser configurable
  - it's now read from a config variable in appSettings.json
  - we default to `Longest` if the config value is not present or not parseable to the JourneyHeuristic enum

This PR is effectively more groundwork - nothing will provide a reference file or set the heuristic config value yet, so group search will remain disabled. Even if we provided the file and set the heuristic, the endpoints would reject station group codes found in inbound requests. Work to allow that will follow in phase 3. 

### Open question
This PR is currently targetting `main` but the hourly deployment from the Seatfrog wrapper repo builds and deploys from the `net8` branch. @Phils0 would you prefer I merge `main` into `net8` in order to "release" (they were at parity before my last PR), or update the wrapper to target `main` by default?

## Testing
Deployed the feature branch to Seatfrog's UAT environment (with the help of [this PR](https://github.com/Seatfrog/uk-timetable-service/pull/11)) and asserted that the startup logs the outcome of looking for the heuristic and station groups file:
<img width="1162" height="528" alt="Xnip2026-05-28_15-22-38" src="https://github.com/user-attachments/assets/2e37a97e-71f1-4f7f-9f75-44bbbd079d3b" />

### Station groups
<img width="1393" height="1400" alt="Xnip2026-05-28_15-23-16" src="https://github.com/user-attachments/assets/fe586f73-748a-414b-b59a-ef06889007d5" />


### Journey heuristic
<img width="1232" height="1053" alt="Xnip2026-05-28_15-22-55" src="https://github.com/user-attachments/assets/c6e363b4-7ede-488b-8f04-76370746c240" />
