### PR TITLE
Order full-day group departure boards chronologically

### DIFF
--- a/Timetable.Web.Test/Controllers/GroupSearchOrchestratorTest.cs
+++ b/Timetable.Web.Test/Controllers/GroupSearchOrchestratorTest.cs
@@ -98,6 +98,48 @@ namespace Timetable.Web.Test.Controllers
             direction.DidNotReceive().Optimise(Arg.Any<ResolvedServiceStop[]>(), Arg.Any<StationGroup>(), Arg.Any<StationGroup>());
         }
 
+        // ----- full-day ordering (via the built transform) -----
+
+        [Fact]
+        public void FullDayOrdersTheMergedBoardChronologically()
+        {
+            // The path-side gather concatenates each member's individually-ordered board, so the merged input
+            // is not globally sorted. Full-day must return it as one chronological board.
+            var stops = new[]
+            {
+                DepartingAt("X10003", 10, 10), DepartingAt("X10001", 6, 40),
+                DepartingAt("X10004", 23, 30), DepartingAt("X10002", 8, 20),
+            };
+
+            var result = FullDayDepartures()(stops);
+
+            Assert.Equal(new[] { "X10001", "X10002", "X10003", "X10004" }, Uids(result));
+        }
+
+        [Fact]
+        public void FullDayPlacesAPastMidnightServiceAfterTheSameEvening()
+        {
+            // 00:10 held as 24:10 is the next day, so it sorts after 23:30 - not ahead of everything as a bare 00:10 would.
+            var stops = new[] { DepartingAt("X10002", 24, 10), DepartingAt("X10001", 23, 30) };
+
+            var result = FullDayDepartures()(stops);
+
+            Assert.Equal(new[] { "X10001", "X10002" }, Uids(result));
+        }
+
+        [Fact]
+        public void FullDayLeavesOrderUntouchedWhenOnlyTheQuerySideIsAGroup()
+        {
+            // Path side is a plain CRS: a single, already-ordered board - nothing to merge, so don't reorder it.
+            var orchestrator = new GroupSearchOrchestrator(Substitute.For<ILogger>());
+            var stops = new[] { DepartingAt("X10002", 10, 10), DepartingAt("X10001", 9, 40) };
+
+            var result = orchestrator.BuildOptimise(new PassThroughDeparturesDirection(),
+                pathGroup: null, queryGroup: London, pivot: null, new ResultWindow(0, 0))(stops);
+
+            Assert.Equal(new[] { "X10002", "X10001" }, Uids(result));
+        }
+
         // ----- GatherAcrossGroupMembers -----
 
         [Fact]
@@ -174,6 +216,13 @@ namespace Timetable.Web.Test.Controllers
         {
             var orchestrator = new GroupSearchOrchestrator(Substitute.For<ILogger>());
             return orchestrator.BuildOptimise(new PassThroughDeparturesDirection(), pathGroup: London, queryGroup: null, pivot: pivot, new ResultWindow(before, after));
+        }
+
+        // The transform for a full-day path-side (origin) group departures search: merged board, no windowing.
+        private static Func<ResolvedServiceStop[], ResolvedServiceStop[]> FullDayDepartures()
+        {
+            var orchestrator = new GroupSearchOrchestrator(Substitute.For<ILogger>());
+            return orchestrator.BuildOptimise(new PassThroughDeparturesDirection(), pathGroup: London, queryGroup: null, pivot: null, new ResultWindow(0, 0));
         }
 
         // Stands in for a real controller: Optimise returns its input untouched (so ReWindow operates on exactly the

--- a/Timetable.Web/Controllers/GroupSearchOrchestrator.cs
+++ b/Timetable.Web/Controllers/GroupSearchOrchestrator.cs
@@ -76,10 +76,11 @@ namespace Timetable.Web.Controllers
 
         /// <summary>
         /// Returns the post-dedup transform the controller hands to its Process pipeline: collapse a service's
-        /// member-stops to one canonical row via the direction's optimiser, then - when the path side was a group and
-        /// so over-gathered one window per member (<paramref name="pathGroup"/> non-null, <paramref name="pivot"/>
-        /// non-null = windowed mode) - re-window the merged set back around the request time. When neither side is a
-        /// group the transform is the identity, so the plain-CRS path is byte-for-byte unchanged.
+        /// member-stops to one canonical row via the direction's optimiser. When the path side was a group the
+        /// per-member boards were gathered and concatenated, so the merged set is re-ordered by time: windowed
+        /// (<paramref name="pivot"/> non-null) re-windows around the request time, full-day sorts chronologically.
+        /// When the path side is a plain CRS (single, already-ordered board) the order is left as-is, so the
+        /// plain-CRS path is byte-for-byte unchanged.
         /// </summary>
         public Func<ResolvedServiceStop[], ResolvedServiceStop[]> BuildOptimise(
             IGroupSearchDirection direction, StationGroup? pathGroup, StationGroup? queryGroup, DateTime? pivot, ResultWindow window)
@@ -90,9 +91,12 @@ namespace Timetable.Web.Controllers
             return stops =>
             {
                 var optimised = direction.Optimise(stops, pathGroup, queryGroup);
-                return pathGroup != null && pivot != null
+                if (pathGroup == null)
+                    return optimised;
+
+                return pivot != null
                     ? ReWindow(direction, optimised, pivot.Value, window)
-                    : optimised;
+                    : OrderByInstant(direction, optimised);
             };
         }
 
@@ -105,12 +109,19 @@ namespace Timetable.Web.Controllers
         private static ResolvedServiceStop[] ReWindow(
             IGroupSearchDirection direction, IEnumerable<ResolvedServiceStop> stops, DateTime pivot, ResultWindow window)
         {
-            DateTime InstantOf(ResolvedServiceStop stop) => stop.Stop.On.Add(direction.TimeAtFoundStop(stop).Value);
-
-            var ordered = stops.OrderBy(InstantOf).ToList();
-            var beforePivot = ordered.Where(s => InstantOf(s) < pivot).TakeLast(window.Before);
-            var fromPivot = ordered.Where(s => InstantOf(s) >= pivot).Take(window.After);
+            var ordered = OrderByInstant(direction, stops);
+            var beforePivot = ordered.Where(s => InstantOf(direction, s) < pivot).TakeLast(window.Before);
+            var fromPivot = ordered.Where(s => InstantOf(direction, s) >= pivot).Take(window.After);
             return beforePivot.Concat(fromPivot).ToArray();
         }
+
+        // Orders a merged board chronologically by the absolute instant (running date + stop time), so next-day
+        // stops held as 24:10 sort after the same evening's 23:50 rather than ahead of it as a bare 00:10 would.
+        private static ResolvedServiceStop[] OrderByInstant(
+            IGroupSearchDirection direction, IEnumerable<ResolvedServiceStop> stops) =>
+            stops.OrderBy(s => InstantOf(direction, s)).ToArray();
+
+        private static DateTime InstantOf(IGroupSearchDirection direction, ResolvedServiceStop stop) =>
+            stop.Stop.On.Add(direction.TimeAtFoundStop(stop).Value);
     }
 }

--- a/Timetable.Web/Controllers/GroupSearchOrchestrator.cs
+++ b/Timetable.Web/Controllers/GroupSearchOrchestrator.cs
@@ -96,7 +96,7 @@ namespace Timetable.Web.Controllers
 
                 return pivot != null
                     ? ReWindow(direction, optimised, pivot.Value, window)
-                    : OrderByInstant(direction, optimised);
+                    : OrderChronologically(direction, optimised);
             };
         }
 
@@ -109,19 +109,19 @@ namespace Timetable.Web.Controllers
         private static ResolvedServiceStop[] ReWindow(
             IGroupSearchDirection direction, IEnumerable<ResolvedServiceStop> stops, DateTime pivot, ResultWindow window)
         {
-            var ordered = OrderByInstant(direction, stops);
-            var beforePivot = ordered.Where(s => InstantOf(direction, s) < pivot).TakeLast(window.Before);
-            var fromPivot = ordered.Where(s => InstantOf(direction, s) >= pivot).Take(window.After);
+            var ordered = OrderChronologically(direction, stops);
+            var beforePivot = ordered.Where(s => DateTimeAtFoundStop(direction, s) < pivot).TakeLast(window.Before);
+            var fromPivot = ordered.Where(s => DateTimeAtFoundStop(direction, s) >= pivot).Take(window.After);
             return beforePivot.Concat(fromPivot).ToArray();
         }
 
         // Orders a merged board chronologically by the absolute instant (running date + stop time), so next-day
         // stops held as 24:10 sort after the same evening's 23:50 rather than ahead of it as a bare 00:10 would.
-        private static ResolvedServiceStop[] OrderByInstant(
+        private static ResolvedServiceStop[] OrderChronologically(
             IGroupSearchDirection direction, IEnumerable<ResolvedServiceStop> stops) =>
-            stops.OrderBy(s => InstantOf(direction, s)).ToArray();
+            stops.OrderBy(s => DateTimeAtFoundStop(direction, s)).ToArray();
 
-        private static DateTime InstantOf(IGroupSearchDirection direction, ResolvedServiceStop stop) =>
+        private static DateTime DateTimeAtFoundStop(IGroupSearchDirection direction, ResolvedServiceStop stop) =>
             stop.Stop.On.Add(direction.TimeAtFoundStop(stop).Value);
     }
 }


### PR DESCRIPTION
The scope of this PR is to fix an issue introduced with the station groups changes. Namely when a station group is used as the path parameter of a request, the results appear out of order. This is because the gathering across a group's members concatenates each member's individually-ordered board, so the merged set isn't globally sorted.

e.g.
`GET /departures/GB@MA/2026-06-23?to=LIV&fullDay=true` returns 105 services, all correct — but the 00:12 Manchester Victoria → Liverpool service lands at position 70, not the top. The board comes back as two separately-sorted runs (the MAN/MCO members merged, then MCV appended), so the day's earliest departure sits two-thirds of the way down.

## The fix

Order the merged full-day board by the same day-aware absolute-instant key (running date + stop time) the windowed path already uses

## Notes
This PR's branch is based off of the one from this PR which fixes missing services under a particular edge case.
https://github.com/Phils0/UkTimetableService/pull/39


## Testing
- New unit tests added
- Manual testing locally:

### Before:
With a group search, A29412 at 00:12 does appear in the results list, but much further down than it should
<img width="1281" height="1077" alt="image" src="https://github.com/user-attachments/assets/2d2f7f49-87f0-44b7-adbf-6120e004008c" />

### After:
With a group search, A29412 at 00:12 still appears in the results list, but now directly after C24988 which departs MCV at 00:01

<img width="1282" height="1111" alt="image" src="https://github.com/user-attachments/assets/d3b56189-5952-4697-a8ed-d13b79b3902b" />
